### PR TITLE
Reduce reconnection decay to 1.01

### DIFF
--- a/src/js/reconnecting-websocket.js
+++ b/src/js/reconnecting-websocket.js
@@ -122,7 +122,7 @@
             /** The maximum number of milliseconds to delay a reconnection attempt. */
             maxReconnectInterval: 30000,
             /** The rate of increase of the reconnect delay. Allows reconnect attempts to back off when problems persist. */
-            reconnectDecay: 1.5,
+            reconnectDecay: 1.01,
 
             /** The maximum time in milliseconds to wait for a connection to succeed before closing and retrying. */
             timeoutInterval: 2000,


### PR DESCRIPTION
* Current value of 1.5 decays to the maximimum reconnection delay of
  30 seconds in only 58 seconds.

* Proposed value of 1.01 decays to 30 second reconnects in 2900 seconds.

* Cost of reconnection attempts is very small.