### PR TITLE
Get BP server URL from query parameters

### DIFF
--- a/src/js/bp_host.js
+++ b/src/js/bp_host.js
@@ -1,7 +1,23 @@
+function getQueryParams(qs) {
+    qs = qs.split('+').join(' ');
+    var params = {},
+        tokens,
+        re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+        params[decodeURIComponent(tokens[1])] = decodeURIComponent(tokens[2]);
+    }
+    return params;
+}
+
 function bpHost() {
     const BP_HOST_DEFAULT = 'localhost:1337';
     const LS_ENABLED = typeof localStorage !== 'undefined';
     let bpHost = BP_HOST_DEFAULT;
+    // Check if a server URL is specified in the query parameters
+    const params = getQueryParams(document.location.search);
+    if (params.host) {
+        return params.host;
+    }
     if (LS_ENABLED && localStorage.bpHost) {
         bpHost = localStorage.bpHost;
     }


### PR DESCRIPTION
Use Case: Teachers and students programming with BiblioPixel in an online development environment want to open a direct link to the visualization in SimPixel so they can get started faster.

I changed the `bpHost()` function to check if there is a `host` query parameter in the URL and, if there is one, return its value for the BP host. This way, students could have a direct link that connects SimPixel to their own websocket URL.

Is `host` the best name for such a parameter?

Example Link: http://simpixel.io/?host=wss://boring-vor_80.ide.mimir.io

Here, the BiblioPixel program is running on a web-based IDE with the websocket: `wss://boring-vor_80.ide.mimir.io`. When the above link opens, SimPixel will automatically try/retry to connect to that host. I envision this kind of link being automatically generated by an online coding tool so students can just copy/paste the URL or click a button to open the visualization. The SimPixel view could also be iframed so that students don't have to switch tabs when testing.