### PR TITLE
Reconnect faster on interruptions

### DIFF
--- a/src/js/reconnecting-websocket.js
+++ b/src/js/reconnecting-websocket.js
@@ -118,14 +118,14 @@
             automaticOpen: true,
 
             /** The number of milliseconds to delay before attempting to reconnect. */
-            reconnectInterval: 1000,
+            reconnectInterval: 100,
             /** The maximum number of milliseconds to delay a reconnection attempt. */
             maxReconnectInterval: 30000,
             /** The rate of increase of the reconnect delay. Allows reconnect attempts to back off when problems persist. */
             reconnectDecay: 1.01,
 
             /** The maximum time in milliseconds to wait for a connection to succeed before closing and retrying. */
-            timeoutInterval: 2000,
+            timeoutInterval: 300,
 
             /** The maximum number of reconnection attempts to make. Unlimited if null. */
             maxReconnectAttempts: null,


### PR DESCRIPTION
Right now, when you restart the program it's extremely sluggish to reconnect, even if there's almost no pause between stopping one instance of bp and starting the next.

From the code, it looks as if the minimum possible delay is three seconds.  This change reduces that to 300ms.

I don't really see any great downside to these tighter bounds.  If your server can't respond to a simple "hello" in 200ms, even with unlimited retries, it's never going to be able to sustain any actual frame rate.  And the cost of attempting to reconnect and fail is extremely small.

How can I run this locally to test it?