### PR TITLE
Change point size and dark LED visibility via URL parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bower_components
 node_modules
 .idea
 npm-debug.log
+package-lock.json
 
 client/css/.o
 client/css/.o.map

--- a/src/js/bp_host.js
+++ b/src/js/bp_host.js
@@ -11,8 +11,12 @@ function getQueryParams(qs) {
 
 function bpParams() {
     const BP_HOST_DEFAULT = 'ws://localhost:1337';
+    const BP_SIZE_DEFAULT = 5;
+    const BP_DARK_DEFAULT = true;
     const LS_ENABLED = typeof localStorage !== 'undefined';
     let bpHost = BP_HOST_DEFAULT;
+    let bpSize = BP_SIZE_DEFAULT;
+    let bpDark = BP_DARK_DEFAULT;
     // Check if a server URL is specified in the query parameters
     const params = getQueryParams(document.location.search);
     if (params.host) {
@@ -20,15 +24,27 @@ function bpParams() {
     } else if (LS_ENABLED && localStorage.bpHost) {
         bpHost = localStorage.bpHost;
     }
-    if (LS_ENABLED) {
-        localStorage.bpHost = bpHost;
-    }
-    let bpSize = 5;
+    // Check if point size is specified in the query parameters
     if (!isNaN(params.size)) {
         bpSize = parseInt(params.size);
+    } else if (LS_ENABLED && localStorage.bpSize) {
+        bpSize = localStorage.bpSize;
+    }
+    if (params.dark === 'show') {
+        bpDark = true;
+    } else if (params.dark === 'hide') {
+        bpDark = false;
+    } else if (LS_ENABLED && localStorage.bpDark) {
+        bpDark = localStorage.bpDark;
+    }
+    if (LS_ENABLED) {
+        localStorage.bpHost = bpHost;
+        localStorage.bpSize = bpSize;
+        localStorage.bpDark = bpDark;
     }
     return {
         host: bpHost,
-        size: bpSize
+        size: bpSize,
+        dark: bpDark
     }
 }

--- a/src/js/bp_host.js
+++ b/src/js/bp_host.js
@@ -9,20 +9,26 @@ function getQueryParams(qs) {
     return params;
 }
 
-function bpHost() {
-    const BP_HOST_DEFAULT = 'localhost:1337';
+function bpParams() {
+    const BP_HOST_DEFAULT = 'ws://localhost:1337';
     const LS_ENABLED = typeof localStorage !== 'undefined';
     let bpHost = BP_HOST_DEFAULT;
     // Check if a server URL is specified in the query parameters
     const params = getQueryParams(document.location.search);
     if (params.host) {
-        return params.host;
-    }
-    if (LS_ENABLED && localStorage.bpHost) {
+        bpHost = params.host;
+    } else if (LS_ENABLED && localStorage.bpHost) {
         bpHost = localStorage.bpHost;
     }
     if (LS_ENABLED) {
         localStorage.bpHost = bpHost;
     }
-    return 'ws://' + bpHost;
+    let bpSize = 5;
+    if (!isNaN(params.size)) {
+        bpSize = parseInt(params.size);
+    }
+    return {
+        host: bpHost,
+        size: bpSize
+    }
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -20,9 +20,17 @@ network.onError( err => {
 network.onConf( conf => {
     view.init(conf);
     // Set point size if in config parameters
-    if (params.size) {
-        view.sizeDefault = params.size;
-        view.adjustViewportFields();
+    view.sizeDefault = params.size;
+    view.adjustViewportFields();
+    // Set dark LEDs if in config parameters
+    view.darkLEDsVisible = params.dark;
+    view.showDarkLEDs(view.darkLEDsVisible);
+    // Iterate over all controllers to update parameters
+    const gui = view.gui;
+    if (gui) {
+        for (var i in gui.__controllers) {
+            gui.__controllers[i].updateDisplay();
+        }
     }
     netStatusDisplay.innerHTML = '';
 });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,7 +1,8 @@
 if ( ! Detector.webgl ) Detector.addGetWebGLMessage();
 
 const view = new View('#container');
-const network = new Network( bpHost(), 1000 );
+const params = bpParams()
+const network = new Network( params.host, 1000 );
 const netStatusDisplay = document.querySelector('#connection');
 
 // create a conf panel and allow each module to register its own configuration
@@ -18,6 +19,11 @@ network.onError( err => {
 });
 network.onConf( conf => {
     view.init(conf);
+    // Set point size if in config parameters
+    if (params.size) {
+        view.sizeDefault = params.size;
+        view.adjustViewportFields();
+    }
     netStatusDisplay.innerHTML = '';
 });
 network.onColor( view.update.bind(view) );

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -19,19 +19,9 @@ network.onError( err => {
 });
 network.onConf( conf => {
     view.init(conf);
-    // Set point size if in config parameters
-    view.sizeDefault = params.size;
-    view.adjustViewportFields();
-    // Set dark LEDs if in config parameters
-    view.darkLEDsVisible = params.dark;
-    view.showDarkLEDs(view.darkLEDsVisible);
-    // Iterate over all controllers to update parameters
-    const gui = view.gui;
-    if (gui) {
-        for (var i in gui.__controllers) {
-            gui.__controllers[i].updateDisplay();
-        }
-    }
+    // Set point size and dark LEDs if in config parameters
+    view.updateSizeDefault(params.size);
+    view.updateDarkVisible(params.dark);
     netStatusDisplay.innerHTML = '';
 });
 network.onColor( view.update.bind(view) );

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -11,6 +11,7 @@ class View {
         this.initialized = false;
         this.darkLEDsVisible = true;
         this.sizeDefault = 5;
+        this.gui = null;
     }
     init(positions) {
         this.removeParticleSystem(); // in case we were initialized already
@@ -173,6 +174,8 @@ class View {
 
         panel.add(this, 'toggle_fullscreen')
             .name('Fullscreen');
+
+        this.gui = panel;
 
     }
     showDarkLEDs(bool) {

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -11,7 +11,6 @@ class View {
         this.initialized = false;
         this.darkLEDsVisible = true;
         this.sizeDefault = 5;
-        this.panel = null;
     }
     init(positions) {
         this.removeParticleSystem(); // in case we were initialized already
@@ -139,7 +138,7 @@ class View {
     }
     adjustViewportFields() {
         this.material.uniforms.size.value = this.sizeDefault * this.heightScale;
-        this.panel.remember(this);
+        this.rememberParams();
     }
     removeParticleSystem() {
         // this should be enough to free all memory, making re-initialization
@@ -176,12 +175,10 @@ class View {
         panel.add(this, 'toggle_fullscreen')
             .name('Fullscreen');
 
-        this.panel = panel;
-
     }
     showDarkLEDs(bool) {
         this.particleSystem.material.uniforms.uDarkLEDsVisible.value = ~~bool;
-        this.panel.remember(this);
+        this.rememberParams();
     }
     updateControllers() {
         // Iterate over all controllers to update parameters
@@ -198,6 +195,10 @@ class View {
         this.darkLEDsVisible = val;
         this.showDarkLEDs(this.darkLEDsVisible);
         this.updateControllers();
+    }
+    rememberParams() {
+        localStorage.bpSize = this.sizeDefault;
+        localStorage.bpDark = this.darkLEDsVisible;
     }
     reset_camera() {
         this.controls.reset();

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -11,7 +11,7 @@ class View {
         this.initialized = false;
         this.darkLEDsVisible = true;
         this.sizeDefault = 5;
-        this.gui = null;
+        this.panel = null;
     }
     init(positions) {
         this.removeParticleSystem(); // in case we were initialized already
@@ -139,6 +139,7 @@ class View {
     }
     adjustViewportFields() {
         this.material.uniforms.size.value = this.sizeDefault * this.heightScale;
+        this.panel.remember(this);
     }
     removeParticleSystem() {
         // this should be enough to free all memory, making re-initialization
@@ -175,11 +176,28 @@ class View {
         panel.add(this, 'toggle_fullscreen')
             .name('Fullscreen');
 
-        this.gui = panel;
+        this.panel = panel;
 
     }
     showDarkLEDs(bool) {
         this.particleSystem.material.uniforms.uDarkLEDsVisible.value = ~~bool;
+        this.panel.remember(this);
+    }
+    updateControllers() {
+        // Iterate over all controllers to update parameters
+        for (var i in panel.__controllers) {
+            panel.__controllers[i].updateDisplay();
+        }
+    }
+    updateSizeDefault(val) {
+        this.sizeDefault = val;
+        this.adjustViewportFields();
+        this.updateControllers();
+    }
+    updateDarkVisible(val) {
+        this.darkLEDsVisible = val;
+        this.showDarkLEDs(this.darkLEDsVisible);
+        this.updateControllers();
     }
     reset_camera() {
         this.controls.reset();


### PR DESCRIPTION
Builds on #28 by checking URL parameters to customize point size and dark LED visibility.

## Set view to URL parameters

I followed @adammhaile 's suggestion to modify `bpHost()` into a new function `bpParams()` that returns a dict of three settings: websocket host, point size, and dark LED visibility. I added two methods to the View class (`updateSizeDefault(val)` and `updateDarkVisible(val)`) to set point size and dark LED visibility from main.js and update the display. Those methods also take care of updating the GUI panel controllers, [as recommended in the data-gui documentation.](http://workshop.chromeexperiments.com/examples/gui/#10--Updating-the-Display-Manually)

The URL parameters are:
- `size`: integer
- `dark`: `on` or `off`

An example URL would be:
https://simpixel.io/?host=wss://dreamy-elli_80.ide.mimir.io&size=7&dark=on

## Remember parameters in localStorage

I also incorporated @mwcz 's suggestion to save the parameters in localStorage, if possible. I tried the data-gui `remember()` first, but it added extra selectors and buttons to the top of the panel, which seemed like too much. Instead, I added a method to the View class called `rememberParams()` to save point size and dark LED visibility to localStorage when they are updated.